### PR TITLE
Use stable dimension filter IDs and add null-safe UUID handling in user settings

### DIFF
--- a/Common/src/main/java/games/alejandrocoria/mapfrontiers/client/gui/screen/FrontierList.java
+++ b/Common/src/main/java/games/alejandrocoria/mapfrontiers/client/gui/screen/FrontierList.java
@@ -34,11 +34,19 @@ import net.minecraft.util.StringUtil;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @ParametersAreNonnullByDefault
 public class FrontierList extends AutoScaledScreen {
+    private static final int FILTER_DIMENSION_ALL_ID = 0;
+    private static final int FILTER_DIMENSION_CURRENT_ID = 1;
+    private static final int FILTER_DIMENSION_OVERWORLD_ID = 2;
+    private static final int FILTER_DIMENSION_NETHER_ID = 3;
+    private static final int FILTER_DIMENSION_END_ID = 4;
+
     private static final Component titleLabel = Component.translatable("mapfrontiers.title_frontiers");
     private static final Component resetFiltersLabel = Component.translatable("mapfrontiers.reset_filters");
     private static final Component filterTypeLabel = Component.translatable("mapfrontiers.filter_type");
@@ -72,6 +80,7 @@ public class FrontierList extends AutoScaledScreen {
     private SimpleButton buttonVisible;
     private SimpleButton buttonSettings;
     private SimpleButton buttonDone;
+    private final Map<Integer, String> dimensionFilterById = new HashMap<>();
 
     public FrontierList(IClientAPI jmAPI, FullscreenMap fullscreenMap) {
         super(titleLabel, 778, 302);
@@ -139,7 +148,7 @@ public class FrontierList extends AutoScaledScreen {
             Config.filterFrontierOwner = Config.FilterFrontierOwner.All;
             filterOwner.selectElementIf((element) -> ((RadioListElement) element).getId() == Config.filterFrontierOwner.ordinal());
             Config.filterFrontierDimension = "all";
-            filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == Config.filterFrontierDimension.hashCode());
+            filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == FILTER_DIMENSION_ALL_ID);
             updateFrontiers();
             updateButtons();
         });
@@ -184,29 +193,31 @@ public class FrontierList extends AutoScaledScreen {
         rightColumn.addChild(SpacerElement.height(4));
         rightColumn.addChild(new StringWidget(filterDimensionLabel, font).setColor(ColorConstants.TEXT));
         filterDimension = new ScrollBox(actualHeight - 274, 200, 16);
-        filterDimension.addElement(new RadioListElement(font, configAllLabel, "all".hashCode()));
-        filterDimension.addElement(new RadioListElement(font, configCurrentLabel, "current".hashCode()));
-        filterDimension.addElement(new RadioListElement(font, overworldLabel, "minecraft:overworld".hashCode()));
-        filterDimension.addElement(new RadioListElement(font, theNetherLabel, "minecraft:the_nether".hashCode()));
-        filterDimension.addElement(new RadioListElement(font, theEndLabel, "minecraft:the_end".hashCode()));
+        filterDimension.addElement(new RadioListElement(font, configAllLabel, FILTER_DIMENSION_ALL_ID));
+        filterDimension.addElement(new RadioListElement(font, configCurrentLabel, FILTER_DIMENSION_CURRENT_ID));
+        filterDimension.addElement(new RadioListElement(font, overworldLabel, FILTER_DIMENSION_OVERWORLD_ID));
+        filterDimension.addElement(new RadioListElement(font, theNetherLabel, FILTER_DIMENSION_NETHER_ID));
+        filterDimension.addElement(new RadioListElement(font, theEndLabel, FILTER_DIMENSION_END_ID));
+
+        dimensionFilterById.clear();
+        dimensionFilterById.put(FILTER_DIMENSION_ALL_ID, "all");
+        dimensionFilterById.put(FILTER_DIMENSION_CURRENT_ID, "current");
+        dimensionFilterById.put(FILTER_DIMENSION_OVERWORLD_ID, "minecraft:overworld");
+        dimensionFilterById.put(FILTER_DIMENSION_NETHER_ID, "minecraft:the_nether");
+        dimensionFilterById.put(FILTER_DIMENSION_END_ID, "minecraft:the_end");
+
         addDimensionsToFilter();
-        filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == Config.filterFrontierDimension.hashCode());
+        filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == getDimensionFilterId(Config.filterFrontierDimension));
         filterDimension.setElementClickedCallback(element -> {
             int selected = ((RadioListElement) element).getId();
-            if (selected == "all".hashCode()) {
-                Config.filterFrontierDimension = "all";
-            } else if (selected == "current".hashCode()) {
-                Config.filterFrontierDimension = "current";
-            } else {
-                Config.filterFrontierDimension = getDimensionFromHash(selected);
-            }
+            Config.filterFrontierDimension = dimensionFilterById.getOrDefault(selected, "all");
             updateFrontiers();
             ClientEventHandler.postUpdatedConfigEvent();
             updateButtons();
         });
         if (filterDimension.getSelectedElement() == null) {
             Config.filterFrontierDimension = "all";
-            filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == Config.filterFrontierDimension.hashCode());
+            filterDimension.selectElementIf((element) -> ((RadioListElement) element).getId() == FILTER_DIMENSION_ALL_ID);
         }
         rightColumn.addChild(filterDimension);
 
@@ -291,22 +302,24 @@ public class FrontierList extends AutoScaledScreen {
 
     private void addDimensionsToFilter() {
         List<String> dimensions = Services.JOURNEYMAP.getDimensionList();
+        int dynamicDimensionId = FILTER_DIMENSION_END_ID + 1;
         for (String dimension : dimensions) {
             if (!dimension.equals("minecraft:overworld") && !dimension.equals("minecraft:the_nether") && !dimension.equals("minecraft:the_end")) {
-                filterDimension.addElement(new RadioListElement(font, Component.literal(dimension), dimension.hashCode()));
+                filterDimension.addElement(new RadioListElement(font, Component.literal(dimension), dynamicDimensionId));
+                dimensionFilterById.put(dynamicDimensionId, dimension);
+                ++dynamicDimensionId;
             }
         }
     }
 
-    private String getDimensionFromHash(int hash) {
-        List<String> dimensions = Services.JOURNEYMAP.getDimensionList();
-        for (String dimension : dimensions) {
-            if (dimension.hashCode() == hash) {
-                return dimension;
+    private int getDimensionFilterId(String dimension) {
+        for (Map.Entry<Integer, String> entry : dimensionFilterById.entrySet()) {
+            if (entry.getValue().equals(dimension)) {
+                return entry.getKey();
             }
         }
 
-        return "";
+        return FILTER_DIMENSION_ALL_ID;
     }
 
     private void updateFrontiers() {
@@ -347,8 +360,9 @@ public class FrontierList extends AutoScaledScreen {
                         return false;
                     }
                 }
-                if (!StringUtil.isBlank(frontier.getOwner().uuid.toString())) {
-                    if (frontier.getOwner().uuid.toString().toLowerCase().contains(searchText)) {
+                if (frontier.getOwner().uuid != null) {
+                    String ownerUuid = frontier.getOwner().uuid.toString().toLowerCase();
+                    if (ownerUuid.contains(searchText)) {
                         return false;
                     }
                 }

--- a/Common/src/main/java/games/alejandrocoria/mapfrontiers/common/settings/SettingsUser.java
+++ b/Common/src/main/java/games/alejandrocoria/mapfrontiers/common/settings/SettingsUser.java
@@ -51,10 +51,18 @@ public class SettingsUser implements Comparable<SettingsUser> {
 
     public void readFromNBT(CompoundTag nbt) {
         username = nbt.getStringOr("username", "");
+
+        String rawUUID = nbt.getStringOr("UUID", "");
+        if (StringUtils.isBlank(rawUUID)) {
+            uuid = null;
+            return;
+        }
+
         try {
-            uuid = UUID.fromString(nbt.getStringOr("UUID", ""));
-        } catch (Exception e) {
-            MapFrontiers.LOGGER.error(e.getMessage(), e);
+            uuid = UUID.fromString(rawUUID);
+        } catch (IllegalArgumentException e) {
+            uuid = null;
+            MapFrontiers.LOGGER.warn("Invalid UUID in SettingsUser NBT: {}", rawUUID, e);
         }
     }
 
@@ -99,7 +107,11 @@ public class SettingsUser implements Comparable<SettingsUser> {
 
     @Override
     public int hashCode() {
-        return uuid.hashCode();
+        if (uuid != null) {
+            return uuid.hashCode();
+        }
+
+        return username == null ? 0 : username.hashCode();
     }
 
     @Override
@@ -109,11 +121,11 @@ public class SettingsUser implements Comparable<SettingsUser> {
         }
 
         if (other instanceof SettingsUser user) {
-            if (uuid != null) {
-                return uuid.equals(user.uuid);
+            if (uuid != null || user.uuid != null) {
+                return uuid != null && uuid.equals(user.uuid);
             }
 
-            return username.equals(user.username);
+            return username != null && username.equals(user.username);
         }
 
         return false;

--- a/Common/src/main/java/games/alejandrocoria/mapfrontiers/common/settings/SettingsUserShared.java
+++ b/Common/src/main/java/games/alejandrocoria/mapfrontiers/common/settings/SettingsUserShared.java
@@ -83,7 +83,7 @@ public class SettingsUserShared {
             } catch (IllegalArgumentException e) {
                 String userName = user.username;
                 if (userName.isEmpty()) {
-                    userName = user.uuid.toString();
+                    userName = user.uuid == null ? "<unknown>" : user.uuid.toString();
                 }
 
                 String availableActions = StringHelper.enumValuesToString(Arrays.asList(Action.values()));


### PR DESCRIPTION
### Motivation
- Replace usage of `String.hashCode()` for dimension filters with stable integer IDs to avoid collisions and make dynamic dimensions predictable.
- Make user UUID handling and equality/hash logic null-safe to prevent NPEs when reading malformed or missing UUIDs from NBT or when comparing users.
- Prevent crashes/log spam when reading unknown actions by defensively handling a missing `uuid` in `SettingsUserShared`.

### Description
- Introduced integer constants (`FILTER_DIMENSION_*`) and a `Map<Integer,String> dimensionFilterById` in `FrontierList` to map filter IDs to dimension strings and replaced all `hashCode()`-based IDs with these stable IDs.
- Added dynamic ID assignment for non-standard dimensions in `addDimensionsToFilter()` and a helper `getDimensionFilterId()` to map existing config strings back to IDs, and updated selection/callback logic accordingly.
- Made search filtering null-safe by checking `frontier.getOwner().uuid != null` before converting to string in `FrontierList`.
- Improved `SettingsUser.readFromNBT()` to handle blank/invalid UUID strings safely, log invalid UUIDs with a warning, and avoid throwing on parse errors.
- Updated `SettingsUser.hashCode()` and `SettingsUser.equals()` to handle `null` UUIDs and fall back to `username` when appropriate to avoid NPEs and inconsistent behavior.
- Fixed `SettingsUserShared.readFromNBT()` logging to avoid NPE by printing `"<unknown>"` when `user.uuid` is `null`.

### Testing
- Ran a full project build with `./gradlew build` which completed successfully.
- Executed the codebase unit tests via `./gradlew test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c991a664833282878935f425cc52)